### PR TITLE
AsyncRequestTokenUrl 부분 onPostExecute 수정(예외 처리)

### DIFF
--- a/TwitterVoice/src/main/java/kai/twitter/voice/LoginActivity.java
+++ b/TwitterVoice/src/main/java/kai/twitter/voice/LoginActivity.java
@@ -81,7 +81,6 @@ public class LoginActivity extends Activity {
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-
             processDialog = new ProgressDialog(context);
             processDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
             processDialog.show();
@@ -90,7 +89,7 @@ public class LoginActivity extends Activity {
         @Override
         protected void onPostExecute(Void aVoid) {
             super.onPostExecute(aVoid);
-            processDialog.dismiss();
+            if ((processDialog != null) && (processDialog.isShowing())) processDialog.dismiss();
             if (rqToken != null) {
                 webview.loadUrl(rqToken.getAuthorizationURL());
             } else {


### PR DESCRIPTION
processDialog 가 사라진 상태에서, onPostExecute를 통과하게 되면 java.lang.IllegalArgumentException : View not attached to windows manager 가 발생하게 됩니다. 이러한 경우를 대비하여 dismiss 되기 전 null 체크, 실제로 보여지고 있는지 체크하여 예외처리 합니다.
